### PR TITLE
Fix active class

### DIFF
--- a/lib/Link.js
+++ b/lib/Link.js
@@ -101,7 +101,11 @@ module.exports = createClass({
     }
 
     if (currentRoute.path === attributes.href) {
+
+      if (attributes.className) attributes.className += ' ';
+
       attributes.className += this.props.activeClassName;
+
     }
 
     return a(attributes, this.props.children);


### PR DESCRIPTION
If have any className props, insert a blank space at the end of classes to no break the style when insert the activeClassName.
